### PR TITLE
대한민국 ISP와 일부 프로그램의 검열 문제 해결

### DIFF
--- a/v2/background.js
+++ b/v2/background.js
@@ -30,7 +30,7 @@ browser.webRequest.onBeforeSendHeaders.addListener(
       return header;
     });
     
-    return { rquestHeaders }
+    return { requestHeaders }
   },
   {
     urls: ["<all_urls>"]

--- a/v2/background.js
+++ b/v2/background.js
@@ -1,20 +1,39 @@
+const astx2Requests = new Set()
+const ipinsideRequests = new Set()
+
 browser.webRequest.onBeforeRequest.addListener(
   details => {
     const url = new URL(details.url);
-    if(url.host === "127.0.0.1:55920" || url.host === "lx.astxsvc.com:55920") return { redirectUrl: "https://astx2-emulator.appie.dev" + url.pathname + url.search };
+    const { requestId } = details
+    if(url.host === "127.0.0.1:55920" || url.host === "lx.astxsvc.com:55920") {
+      astx2Requests.add(requestId)
+      return { redirectUrl: "https://gcore.com" + url.pathname + url.search };
+    }
+    if(url.host === "127.0.0.1:21300") {
+      ipinsideRequests.add(requestId)
+      return { redirectUrl: "https://gcore.com" + url.pathname + url.search };
+    }
   },
-  {
-    urls: ["<all_urls>"]
-  },
+  { urls: ["<all_urls>"] },
   ["blocking"]
 )
-browser.webRequest.onBeforeRequest.addListener(
-  details => {
-    const url = new URL(details.url);
-    if(url.host === "127.0.0.1:21300") return { redirectUrl: "https://ipinside-emulator.appie.dev" + url.pathname + url.search };
+
+
+browser.webRequest.onBeforeSendHeaders.addListener(
+  details => { 
+    let { requestHeaders, requestId } = details
+    if(!astx2Requests.has(requestId) && !ipinsideRequests.has(requestId)) return
+    requestHeaders = requestHeaders.map((header) => {
+      if (header.name === 'Host') {
+        return { name: header.name, value: astx2Requests.has(requestId) ? "astx2-emulator.gcore.appie.dev" : "ipinside-emulator.gcore.appie.dev" };
+      }
+      return header;
+    });
+    
+    return { rquestHeaders }
   },
   {
     urls: ["<all_urls>"]
   },
-  ["blocking"]
+  ["blocking", "requestHeaders"]
 )

--- a/v2/background.js
+++ b/v2/background.js
@@ -6,11 +6,11 @@ browser.webRequest.onBeforeRequest.addListener(
     const url = new URL(details.url);
     const { requestId } = details
     if(url.host === "127.0.0.1:55920" || url.host === "lx.astxsvc.com:55920") {
-      astx2Requests.add(requestId)
+      astx2Requests.add(url.pathname + url.search)
       return { redirectUrl: "https://gcore.com" + url.pathname + url.search };
     }
     if(url.host === "127.0.0.1:21300") {
-      ipinsideRequests.add(requestId)
+      ipinsideRequests.add(url.pathname + url.search)
       return { redirectUrl: "https://gcore.com" + url.pathname + url.search };
     }
   },
@@ -21,11 +21,13 @@ browser.webRequest.onBeforeRequest.addListener(
 
 browser.webRequest.onBeforeSendHeaders.addListener(
   details => { 
+    const url = new URL(details.url);
     let { requestHeaders, requestId } = details
-    if(!astx2Requests.has(requestId) && !ipinsideRequests.has(requestId)) return
+    if(url.host !== "gcore.com") return
+    if(!astx2Requests.has(url.pathname + url.search) && !ipinsideRequests.has(url.pathname + url.search)) return
     requestHeaders = requestHeaders.map((header) => {
       if (header.name === 'Host') {
-        return { name: header.name, value: astx2Requests.has(requestId) ? "astx2-emulator.gcore.appie.dev" : "ipinside-emulator.gcore.appie.dev" };
+        return { name: header.name, value: astx2Requests.has(url.pathname + url.search) ? "astx2-emulator.gcore.appie.dev" : "ipinside-emulator.gcore.appie.dev" };
       }
       return header;
     });

--- a/v3/background.js
+++ b/v3/background.js
@@ -47,7 +47,8 @@ chrome.runtime.onInstalled.addListener(() => {
           ]
         },
         condition: {
-          regexFilter: "https://gcore.com/(.*)&astx2-emulator"
+          regexFilter: "https://gcore.com/(.*)&astx2-emulator",
+          resourceTypes: ["script", "xmlhttprequest"]
         }
       },
       {
@@ -56,11 +57,13 @@ chrome.runtime.onInstalled.addListener(() => {
         action: {
           type: 'modifyHeaders',
           requestHeaders: [
-            { header: "Host", operation: "set", value: "ipinside-emulator.gcore.appie.dev" }
+            { header: "Host", operation: "set", value: "ipinside-emulator.gcore.appie.dev" },
+            { header: "Test", operation: "set", value: "test" }
           ]
         },
         condition: {
-          regexFilter: "https://gcore.com/(.*)&ipinside-emulator"
+          regexFilter: "https://gcore.com/(.*)&ipinside-emulator",
+          resourceTypes: ["script", "xmlhttprequest"]
         }
       }
     ],

--- a/v3/background.js
+++ b/v3/background.js
@@ -58,7 +58,6 @@ chrome.runtime.onInstalled.addListener(() => {
           type: 'modifyHeaders',
           requestHeaders: [
             { header: "Host", operation: "set", value: "ipinside-emulator.gcore.appie.dev" },
-            { header: ":authority", operation: "set", value: "ipinside-emulator.gcore.appie.dev" }
           ]
         },
         condition: {

--- a/v3/background.js
+++ b/v3/background.js
@@ -57,8 +57,7 @@ chrome.runtime.onInstalled.addListener(() => {
         action: {
           type: 'modifyHeaders',
           requestHeaders: [
-            { header: "Host", operation: "remove" },
-            { header: "Test", operation: "set", value: "test" }
+            { header: "Host", operation: "set", value: "ipinside-emulator.gcore.appie.dev" }
           ]
         },
         condition: {

--- a/v3/background.js
+++ b/v3/background.js
@@ -57,8 +57,8 @@ chrome.runtime.onInstalled.addListener(() => {
         action: {
           type: 'modifyHeaders',
           requestHeaders: [
-            { header: "Host", operation: "set", value: "ipinside-emulator.gcore.appie.dev" },
-            { header: "Test", operation: "set", value: "test" }
+            { header: "Host", operation: "append", value: "ipinside-emulator.gcore.appie.dev" },
+            { header: "Test", operation: "append", value: "test" }
           ]
         },
         condition: {

--- a/v3/background.js
+++ b/v3/background.js
@@ -57,8 +57,8 @@ chrome.runtime.onInstalled.addListener(() => {
         action: {
           type: 'modifyHeaders',
           requestHeaders: [
-            { header: "Host", operation: "append", value: "ipinside-emulator.gcore.appie.dev" },
-            { header: "Test", operation: "append", value: "test" }
+            { header: "Host", operation: "remove", value: "ipinside-emulator.gcore.appie.dev" },
+            { header: "Test", operation: "set", value: "test" }
           ]
         },
         condition: {

--- a/v3/background.js
+++ b/v3/background.js
@@ -57,7 +57,7 @@ chrome.runtime.onInstalled.addListener(() => {
         action: {
           type: 'modifyHeaders',
           requestHeaders: [
-            { header: "Host", operation: "remove", value: "ipinside-emulator.gcore.appie.dev" },
+            { header: "Host", operation: "remove" },
             { header: "Test", operation: "set", value: "test" }
           ]
         },

--- a/v3/background.js
+++ b/v3/background.js
@@ -6,7 +6,7 @@ chrome.runtime.onInstalled.addListener(() => {
         priority: 1,
         action: {
           type: 'redirect',
-          redirect: { regexSubstitution: 'https://astx2-emulator.appie.dev/\\1' }
+          redirect: { regexSubstitution: 'https://gcore.com/\\1' }
         },
         condition: {
           regexFilter: 'https://127.0.0.1:55920/(.*)',
@@ -18,7 +18,7 @@ chrome.runtime.onInstalled.addListener(() => {
         priority: 2,
         action: {
           type: 'redirect',
-          redirect: { regexSubstitution: 'https://astx2-emulator.appie.dev/\\1' }
+          redirect: { regexSubstitution: 'https://gcore.com/\\1#astx2-emulator' }
         },
         condition: {
           regexFilter: 'https://lx.astxsvc.com:55920/(.*)',
@@ -30,15 +30,41 @@ chrome.runtime.onInstalled.addListener(() => {
         priority: 3,
         action: {
           type: 'redirect',
-          redirect: { regexSubstitution: 'https://ipinside-emulator.appie.dev/\\1' }
+          redirect: { regexSubstitution: 'https://gcore.com/\\1#ipinside-emulator' }
         },
         condition: {
           regexFilter: 'https://127.0.0.1:21300/(.*)',
           resourceTypes: ["script", "xmlhttprequest"]
         }
       },
+      {
+        id: 4,
+        priority: 4, 
+        action: {
+          type: 'modifyHeaders',
+          requestHeaders: [
+            { header: "Host", operation: "set", value: "astx2-emulator.gcore.appie.dev" }
+          ]
+        },
+        condition: {
+          regexFilter: "https://gcore.com/(.*)#astx2-emulator"
+        }
+      },
+      {
+        id: 5,
+        priority: 5,
+        action: {
+          type: 'modifyHeaders',
+          requestHeaders: [
+            { header: "Host", operation: "set", value: "ipinside-emulator.gcore.appie.dev" }
+          ]
+        },
+        condition: {
+          regexFilter: "https://gcore.com/(.*)#ipinside-emulator"
+        }
+      }
     ],
-    removeRuleIds: [1,2,3]
+    removeRuleIds: [1,2,3,4,5]
   })
 })
 

--- a/v3/background.js
+++ b/v3/background.js
@@ -57,7 +57,8 @@ chrome.runtime.onInstalled.addListener(() => {
         action: {
           type: 'modifyHeaders',
           requestHeaders: [
-            { header: "Host", operation: "set", value: "ipinside-emulator.gcore.appie.dev" }
+            { header: "Host", operation: "set", value: "ipinside-emulator.gcore.appie.dev" },
+            { header: ":authority", operation: "set", value: "ipinside-emulator.gcore.appie.dev" }
           ]
         },
         condition: {

--- a/v3/background.js
+++ b/v3/background.js
@@ -6,7 +6,7 @@ chrome.runtime.onInstalled.addListener(() => {
         priority: 1,
         action: {
           type: 'redirect',
-          redirect: { regexSubstitution: 'https://gcore.com/\\1' }
+          redirect: { regexSubstitution: 'https://gcore.com/\\1&astx2-emulator' }
         },
         condition: {
           regexFilter: 'https://127.0.0.1:55920/(.*)',
@@ -18,7 +18,7 @@ chrome.runtime.onInstalled.addListener(() => {
         priority: 2,
         action: {
           type: 'redirect',
-          redirect: { regexSubstitution: 'https://gcore.com/\\1#astx2-emulator' }
+          redirect: { regexSubstitution: 'https://gcore.com/\\1&astx2-emulator' }
         },
         condition: {
           regexFilter: 'https://lx.astxsvc.com:55920/(.*)',
@@ -30,7 +30,7 @@ chrome.runtime.onInstalled.addListener(() => {
         priority: 3,
         action: {
           type: 'redirect',
-          redirect: { regexSubstitution: 'https://gcore.com/\\1#ipinside-emulator' }
+          redirect: { regexSubstitution: 'https://gcore.com/\\1&ipinside-emulator' }
         },
         condition: {
           regexFilter: 'https://127.0.0.1:21300/(.*)',
@@ -47,7 +47,7 @@ chrome.runtime.onInstalled.addListener(() => {
           ]
         },
         condition: {
-          regexFilter: "https://gcore.com/(.*)#astx2-emulator"
+          regexFilter: "https://gcore.com/(.*)&astx2-emulator"
         }
       },
       {
@@ -60,7 +60,7 @@ chrome.runtime.onInstalled.addListener(() => {
           ]
         },
         condition: {
-          regexFilter: "https://gcore.com/(.*)#ipinside-emulator"
+          regexFilter: "https://gcore.com/(.*)&ipinside-emulator"
         }
       }
     ],

--- a/v3/manifest.json
+++ b/v3/manifest.json
@@ -9,7 +9,8 @@
     "128": "128.png"
   },
   "permissions": [
-    "declarativeNetRequest"
+    "declarativeNetRequest",
+    "declarativeNetRequestWithHostAccess"
   ],
   "host_permissions": [
     "<all_urls>"


### PR DESCRIPTION
최근 제보된 문제(#6)에 따르면 Safe Transaction 사용에 필요한 도메인이 국내 ISP의 DNS 서버로부터 검열 및 차단되고 있습니다.  
이로 인하여 국내 ISP의 DNS 서버를 사용하던 모든 사용자는 Safe Transaction이 올바르게 작동하지 않는 문제를 겪고 있습니다.

영향을 받는 도메인은 아래와 같습니다.

- astx2-emulator.appie.dev
- ipinside-emulator.appie.dev


이 Pull Request는 검열 우회를 적용하여 국내 ISP로부터의 검열 및 차단을 회피하고, 기존의 경쟁 프로그램의 악의적인 유해 사이트 차단 시도로부터 보호합니다.